### PR TITLE
Align service list style with staff management

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -724,37 +724,44 @@ export default function Admin() {
                 {services.length === 0 ? (
                   <p className="text-gray-500 text-center py-8">ยังไม่มีบริการ</p>
                 ) : (
-                  <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                    {services.map((service) => (
-                      <div
-                        key={service.id}
-                        className="flex justify-between items-center p-4 border rounded-lg bg-white"
-                      >
-                        <div className="flex-1">
-                          <div className="font-medium text-lg">{service.name}</div>
-                          {service.description && (
-                            <div className="text-gray-600 text-sm">{service.description}</div>
-                          )}
-                          <div className="text-sm text-gray-500 mt-1">
-                            ระยะเวลา: {service.duration_minutes} นาที | ราคา: ฿{service.price}
-                          </div>
-                        </div>
-                        <div className="flex space-x-2">
-                          <button
-                            className="btn border bg-yellow-50 hover:bg-yellow-100 text-yellow-700 text-sm px-3 py-1"
-                            onClick={() => startEditService(service)}
-                          >
-                            แก้ไข
-                          </button>
-                          <button
-                            className="btn border bg-red-50 hover:bg-red-100 text-red-700 text-sm px-3 py-1"
-                            onClick={() => deleteService(service.id)}
-                          >
-                            ลบ
-                          </button>
-                        </div>
-                      </div>
-                    ))}
+                  <div className="overflow-x-auto">
+                    <table className="w-full border-collapse">
+                      <thead>
+                        <tr className="bg-gray-100 text-left">
+                          <th className="p-2 border">ชื่อบริการ</th>
+                          <th className="p-2 border">รายละเอียด</th>
+                          <th className="p-2 border">ระยะเวลา</th>
+                          <th className="p-2 border">ราคา</th>
+                          <th className="p-2 border">การจัดการ</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {services.map((service) => (
+                          <tr key={service.id} className="bg-white">
+                            <td className="p-2 border">{service.name}</td>
+                            <td className="p-2 border">{service.description || "-"}</td>
+                            <td className="p-2 border">{service.duration_minutes} นาที</td>
+                            <td className="p-2 border">฿{service.price}</td>
+                            <td className="p-2 border">
+                              <div className="flex space-x-2">
+                                <button
+                                  className="btn border bg-yellow-50 hover:bg-yellow-100 text-yellow-700 text-sm px-3 py-1"
+                                  onClick={() => startEditService(service)}
+                                >
+                                  แก้ไข
+                                </button>
+                                <button
+                                  className="btn border bg-red-50 hover:bg-red-100 text-red-700 text-sm px-3 py-1"
+                                  onClick={() => deleteService(service.id)}
+                                >
+                                  ลบ
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Display services in admin as a table similar to the staff list

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b4273edd9083288c1a9750e95791b0