### PR TITLE
filter available slots

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -30,13 +30,13 @@ export default function Home() {
   // แก้ไขการเรียก slots API
   useEffect(() => {
     if (!date || !selectedService) return;
-    axios.get(`${API}/appointments/slots`, { 
-      params: { 
+    axios.get(`${API}/appointments/slots`, {
+      params: {
         d: date,
-        service_id: selectedService.id 
-      } 
+        service_id: selectedService.id
+      }
     })
-      .then(res => setSlots(res.data.slots || []))
+      .then(res => setSlots((res.data.slots || []).filter((s: Slot) => s.available)))
       .catch(() => setSlots([]));
   }, [date, selectedService]);
 
@@ -68,13 +68,13 @@ export default function Home() {
       setShowSuccessModal(true);
       setSelected(null); setName(""); setPhone(""); setNote("");
       // refresh slots
-      const s = await axios.get(`${API}/appointments/slots`, { 
-        params: { 
+      const s = await axios.get(`${API}/appointments/slots`, {
+        params: {
           d: date,
-          service_id: selectedService.id 
-        } 
+          service_id: selectedService.id
+        }
       });
-      setSlots(s.data.slots || []);
+      setSlots((s.data.slots || []).filter((slot: Slot) => slot.available));
     } catch(e: any) {
       setMessage(e?.response?.data?.detail || "เกิดข้อผิดพลาด");
     }


### PR DESCRIPTION
## Summary
- filter appointment slots on frontend to include only available times

## Testing
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68b465cc59648328b4e8fe2623de1524